### PR TITLE
docs: require cargo fmt before finishing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,5 +76,6 @@ writing style, that takes precedence.
 The following must all pass before creating a PR or claiming work is done:
 
 - `dprint fmt`
+- `cargo fmt`
 - `cargo test`
 - `cargo clippy`


### PR DESCRIPTION
The repository already has a dedicated CI format job for `cargo fmt`, but the local finishing checklist did not mention it. That made it easy to satisfy the documented checklist while still pushing a Rust formatting failure.
