### PR TITLE
fix: escape review hook context json

### DIFF
--- a/claude-code-marketplace/codex-code-review/README.md
+++ b/claude-code-marketplace/codex-code-review/README.md
@@ -5,6 +5,7 @@ A Claude Code plugin that invokes OpenAI's Codex CLI to review code changes.
 ## Prerequisites
 
 - The `codex` CLI must be installed and configured with valid API credentials
+- `jq` must be available for the session-start hook
 - Claude Code with plugin support
 
 ## How It Works

--- a/claude-code-marketplace/codex-code-review/hooks/session-start.sh
+++ b/claude-code-marketplace/codex-code-review/hooks/session-start.sh
@@ -5,11 +5,9 @@ set -eo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
 
-cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "SessionStart",
-    "additionalContext": "CODEX_REVIEW_BIN=${PLUGIN_ROOT}/bin"
+jq -n --arg additional_context "CODEX_REVIEW_BIN=${PLUGIN_ROOT}/bin" '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $additional_context
   }
-}
-EOF
+}'

--- a/claude-code-marketplace/gemini-code-review/README.md
+++ b/claude-code-marketplace/gemini-code-review/README.md
@@ -5,6 +5,7 @@ A Claude Code plugin that invokes Google's Gemini CLI to review code changes.
 ## Prerequisites
 
 - The `gemini` CLI must be installed and configured with valid API credentials
+- `jq` must be available for the session-start hook
 - Claude Code with plugin support
 
 ## How It Works

--- a/claude-code-marketplace/gemini-code-review/hooks/session-start.sh
+++ b/claude-code-marketplace/gemini-code-review/hooks/session-start.sh
@@ -5,11 +5,9 @@ set -eo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
 
-cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "SessionStart",
-    "additionalContext": "GEMINI_REVIEW_BIN=${PLUGIN_ROOT}/bin"
+jq -n --arg additional_context "GEMINI_REVIEW_BIN=${PLUGIN_ROOT}/bin" '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $additional_context
   }
-}
-EOF
+}'

--- a/tests/plugin_hooks.rs
+++ b/tests/plugin_hooks.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+
+fn run_hook(script: &str, env_value: &str) -> serde_json::Value {
+    let output = Command::new("bash")
+        .arg(script)
+        .env("CLAUDE_PLUGIN_ROOT", env_value)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "hook failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn session_hooks_escape_plugin_root_in_json() {
+    for (script, expected) in [
+        (
+            "claude-code-marketplace/codex-code-review/hooks/session-start.sh",
+            "CODEX_REVIEW_BIN=/tmp/plugin \"quoted\"\npath/bin",
+        ),
+        (
+            "claude-code-marketplace/gemini-code-review/hooks/session-start.sh",
+            "GEMINI_REVIEW_BIN=/tmp/plugin \"quoted\"\npath/bin",
+        ),
+    ] {
+        let json = run_hook(script, "/tmp/plugin \"quoted\"\npath");
+
+        assert_eq!(json["hookSpecificOutput"]["additionalContext"], expected);
+    }
+}


### PR DESCRIPTION
The hook output is JSON consumed by Claude Code, so plugin paths need real JSON escaping instead of string interpolation.