### PR TITLE
docs: document review scope policy

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,22 @@
+# SPEC
+
+This file documents repository behavior that is intentional enough that future review should preserve it or update this
+file in the same change.
+
+## Test Coverage Expectations
+
+Installer registration in `src/main.rs` does not need exhaustive integration coverage for every installed payload path.
+Those registrations are mostly data: paths, feature names, and dependency wiring. A small set of integration tests
+should cover the important installer mechanics, but they do not need to duplicate the entire registry.
+
+The library-like pieces of the installer do need good coverage. Feature implementations, graph behavior, path handling,
+JSON merging, and migration logic should have direct tests because regressions there can affect many installed files at
+once.
+
+## Legacy `old/` Tree
+
+Code under `old/` is legacy reference material. Do not spend review effort on simplification, idiomaticity, style, or
+coverage improvements there unless a change explicitly targets that tree.
+
+Security or correctness fixes are still allowed when the user asks for them, but normal repository-wide review should
+treat further cleanup in `old/` as out of scope.


### PR DESCRIPTION
These review-scope choices were marked intentional during repo-swarm triage, so future broad reviews need a local source of truth.