### PR TITLE
fix: clarify review swarm sub-agent wording

### DIFF
--- a/payload/dot_claude/skills/pre-pr-review-swarm/SKILL.md
+++ b/payload/dot_claude/skills/pre-pr-review-swarm/SKILL.md
@@ -26,12 +26,12 @@ clearly no uncommitted changes, fall back to reviewing the current commit.
    - If `commit`: use `git show` for the diff and touched files.
    - Otherwise: use uncommitted changes. If none exist, fall back to `git show`.
 3. Check whether a `SPEC.md` exists at the project root.
-4. Spawn reviewers concurrently using the Agent tool (eight always, plus a ninth if `SPEC.md` exists). Each reviewer
-   runs as its own sub-agent to keep review instructions out of the main context. Do not set the `model` parameter on
-   the Agent calls — omit it so each reviewer inherits the current session's model.
-5. For each reviewer, spawn an Agent with a prompt that includes the review scope (diff and touched files) and instructs
-   the sub-agent to read its charter file before reviewing. Charter files are in the `reviewers/` directory next to this
-   skill file. Tell each sub-agent to read its charter from `<base_directory>/reviewers/<name>.md` where
+4. Spawn reviewers concurrently using the available sub-agent mechanism (eight always, plus a ninth if `SPEC.md`
+   exists). Each reviewer runs as its own sub-agent to keep review instructions out of the main context. Do not set the
+   `model` parameter on sub-agent calls — omit it so each reviewer inherits the current session's model.
+5. For each reviewer, spawn a sub-agent with a prompt that includes the review scope (diff and touched files) and
+   instructs the sub-agent to read its charter file before reviewing. Charter files are in the `reviewers/` directory
+   next to this skill file. Tell each sub-agent to read its charter from `<base_directory>/reviewers/<name>.md` where
    `<base_directory>` is the base directory shown in the skill loading header.
 6. Require each reviewer to return only actionable findings, each tagged as **definite** or **possible**, with file
    references and a short rationale. If a reviewer has zero findings, it returns an empty list—do not invent low-value


### PR DESCRIPTION
The skill is installed into environments whose sub-agent mechanism is not necessarily named Agent.