### PR TITLE
feat: discourage validation boilerplate

### DIFF
--- a/payload/dot_claude/CLAUDE.md
+++ b/payload/dot_claude/CLAUDE.md
@@ -52,6 +52,10 @@ the change is, unless the change is particularly large and a brief TLDR overview
 
 Do not make lists of things changed.
 
+Do not add validation boilerplate to commit messages or PR descriptions. A line like "Tests run: cargo fmt, cargo test,
+cargo clippy" is noise unless the target project's own rules explicitly require that information in the commit or PR
+text. Report checks to the user in the final response instead.
+
 Do not add "Co-Authored-By" trailers or "Generated with Claude Code" badges to commits or PRs.
 
 # Testability and tests


### PR DESCRIPTION
Agent-generated PR and commit text should not repeat routine validation output unless a project explicitly asks for that metadata. The user-facing response is the right place for check results; persisted history should keep the rationale instead.
