### PR TITLE
feat: make pre-pr-review-swarm agent-neutral

### DIFF
--- a/payload/dot_claude/skills/pre-pr-review-swarm/SKILL.md
+++ b/payload/dot_claude/skills/pre-pr-review-swarm/SKILL.md
@@ -14,7 +14,7 @@ The skill accepts optional keyword arguments (case-insensitive, any order):
 - `nofix` — report findings only; do not make any changes to the code.
 - `commit` — review the current commit (`git show`) instead of uncommitted changes.
 
-These can be combined: `/pre-pr-review-swarm nofix commit`
+These can be combined: `nofix commit`
 
 Defaults (no arguments): review uncommitted changes in the working copy, then fix actionable findings. If there are
 clearly no uncommitted changes, fall back to reviewing the current commit.
@@ -26,13 +26,10 @@ clearly no uncommitted changes, fall back to reviewing the current commit.
    - If `commit`: use `git show` for the diff and touched files.
    - Otherwise: use uncommitted changes. If none exist, fall back to `git show`.
 3. Check whether a `SPEC.md` exists at the project root.
-4. Spawn reviewers concurrently using the available sub-agent mechanism (eight always, plus a ninth if `SPEC.md`
-   exists). Each reviewer runs as its own sub-agent to keep review instructions out of the main context. Do not set the
-   `model` parameter on sub-agent calls — omit it so each reviewer inherits the current session's model.
-5. For each reviewer, spawn a sub-agent with a prompt that includes the review scope (diff and touched files) and
-   instructs the sub-agent to read its charter file before reviewing. Charter files are in the `reviewers/` directory
-   next to this skill file. Tell each sub-agent to read its charter from `<base_directory>/reviewers/<name>.md` where
-   `<base_directory>` is the base directory shown in the skill loading header.
+4. Run the reviewer charters concurrently when the environment supports it (eight always, plus a ninth if `SPEC.md`
+   exists). Keep each reviewer focused on its own charter so the review instructions stay separate.
+5. For each reviewer, include the review scope (diff and touched files) and instruct the reviewer to read its charter
+   file before reviewing. Charter files live in the `reviewers/` directory next to this skill file.
 6. Require each reviewer to return only actionable findings, each tagged as **definite** or **possible**, with file
    references and a short rationale. If a reviewer has zero findings, it returns an empty list—do not invent low-value
    observations.

--- a/payload/dot_claude/skills/pre-pr-review-swarm/agents/openai.yaml
+++ b/payload/dot_claude/skills/pre-pr-review-swarm/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Pre-PR Review Swarm"
   short_description: "Run a concurrent multi-angle review before PR creation."
-  default_prompt: "Use $pre-pr-review-swarm to run a final concurrent review pass before asking for PR creation."
+  default_prompt: "Run the pre-pr-review-swarm skill to do a final concurrent review pass before asking for PR creation."

--- a/payload/dot_claude/skills/pre-pr-review-swarm/reviewers/spec-compliance.md
+++ b/payload/dot_claude/skills/pre-pr-review-swarm/reviewers/spec-compliance.md
@@ -16,5 +16,5 @@ divergences—features the spec requires but the change omits, behaviors that co
 covered by the spec.
 
 - When reporting a divergence, quote the relevant spec section.
-- For each divergence, state whether the implementation or the spec appears to be wrong, so the parent agent can decide
+- For each divergence, state whether the implementation or the spec appears to be wrong, so the coordinator can decide
   whether to fix the code or update the spec.

--- a/payload/dot_claude/skills/pre-pr-review-swarm/reviewers/test-quality.md
+++ b/payload/dot_claude/skills/pre-pr-review-swarm/reviewers/test-quality.md
@@ -17,4 +17,4 @@ Evaluate whether the changed code has adequate, meaningful test coverage.
 - Flag edge cases visible in the diff (error paths, boundary values, empty inputs) that have no test coverage.
 - Flag test names or descriptions that don't match what the test actually verifies.
 - Don't flag missing tests for unchanged code, trivial getters/setters, or simple delegations.
-- Don't suggest specific test implementations—identify the gaps and let the parent agent decide how to fill them.
+- Don't suggest specific test implementations—identify the gaps and leave the implementation choice to the coordinator.


### PR DESCRIPTION
The skill had a few references to agent-specific invocation and orchestration details. That made the workflow read like it depended on one runtime even though the review process itself is generic.
