### PR TITLE
docs: document installer invocation directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,11 @@ there — not in `~/.claude/skills/` or elsewhere.
 `lore/*.md` notes, excluding local agent instructions, are historical artifacts. Do not eagerly read them during normal
 work; use them only when digging into past motivation, decisions, or context.
 
+## SPEC.md
+
+Agents must conform to `SPEC.md`. If implementation and `SPEC.md` disagree, treat that as a bug or explicitly update
+`SPEC.md` in the same change.
+
 ## Choosing `feat` vs `docs` for commit types
 
 This repo is an installer — its product is the set of files it installs. Changes to payload files (configs, skills,

--- a/SPEC.md
+++ b/SPEC.md
@@ -3,6 +3,16 @@
 This file documents repository behavior that is intentional enough that future review should preserve it or update this
 file in the same change.
 
+## Invocation Directory
+
+The installer is intended to run from the repository root. Payload-relative paths are resolved against the process
+current working directory, not against the compiled binary path.
+
+This is acceptable for this repository because it is a personal checkout-driven installer, normally run with
+`cargo run -- install` or `cargo run -- uninstall` from the checkout. Future changes may make the base directory
+explicit, but reviews should not treat cwd-relative payload lookup as a bug unless the CLI contract changes at the same
+time.
+
 ## Test Coverage Expectations
 
 Installer registration in `src/main.rs` does not need exhaustive integration coverage for every installed payload path.


### PR DESCRIPTION
This records the current checkout-driven installer contract so future reviews do not treat cwd-relative payload lookup as an accidental bug.
