### PR TITLE
fix: report tilde expansion failures

### DIFF
--- a/src/condition.rs
+++ b/src/condition.rs
@@ -5,31 +5,32 @@
 //! met (e.g., a parent directory doesn't exist).
 
 use std::fmt;
-use std::path::PathBuf;
 
 use crate::util::fs::expand_tilde;
+use anyhow::Result;
 
 /// A condition that must be met for a feature to be installed.
+///
+/// `Ok(false)` means the feature should be skipped. `Err` means the
+/// prerequisite could not be evaluated, so the feature should fail instead of
+/// pretending the prerequisite is simply absent.
 ///
 /// The `Display` impl should describe the condition in human-readable form
 /// for skip messages (e.g., "path exists: ~/.claude").
 pub trait Condition: fmt::Debug + fmt::Display + Send + Sync {
-    fn is_met(&self) -> bool;
+    fn is_met(&self) -> Result<bool>;
 }
 
 /// Condition that checks whether a path exists (file or directory).
 #[derive(Debug)]
 pub struct PathExists {
-    path: PathBuf,
     display_path: String,
 }
 
 impl PathExists {
     pub fn new(path: impl Into<String>) -> Self {
         let path_str = path.into();
-        let expanded = expand_tilde(&path_str).unwrap_or_else(|_| PathBuf::from(&path_str));
         Self {
-            path: expanded,
             display_path: path_str,
         }
     }
@@ -42,8 +43,8 @@ impl fmt::Display for PathExists {
 }
 
 impl Condition for PathExists {
-    fn is_met(&self) -> bool {
-        self.path.exists()
+    fn is_met(&self) -> Result<bool> {
+        Ok(expand_tilde(&self.display_path)?.exists())
     }
 }
 
@@ -60,13 +61,13 @@ mod tests {
         fs::write(&file_path, "content").unwrap();
 
         let condition = PathExists::new(file_path.to_string_lossy().to_string());
-        assert!(condition.is_met());
+        assert!(condition.is_met().unwrap());
     }
 
     #[test]
     fn path_exists_returns_false_when_path_missing() {
         let condition = PathExists::new("/nonexistent/path/that/does/not/exist");
-        assert!(!condition.is_met());
+        assert!(!condition.is_met().unwrap());
     }
 
     #[test]
@@ -74,7 +75,7 @@ mod tests {
         let dir = tempdir().unwrap();
 
         let condition = PathExists::new(dir.path().to_string_lossy().to_string());
-        assert!(condition.is_met());
+        assert!(condition.is_met().unwrap());
     }
 
     #[test]

--- a/src/features/managed_directory.rs
+++ b/src/features/managed_directory.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::fs;
 use std::io;
-use std::path::PathBuf;
 
 use anyhow::{Result, bail};
 use tracing::debug;
@@ -19,17 +18,13 @@ use crate::util::fs::expand_tilde;
 /// a link. The parent directory must already exist.
 #[derive(Debug)]
 pub struct ManagedDirectory {
-    path: PathBuf,
     display_path: String,
 }
 
 impl ManagedDirectory {
     pub fn new(path: impl Into<String>) -> Self {
-        let path_str = path.into();
-        let expanded = expand_tilde(&path_str).unwrap_or_else(|_| PathBuf::from(&path_str));
         Self {
-            path: expanded,
-            display_path: path_str,
+            display_path: path.into(),
         }
     }
 }
@@ -42,24 +37,28 @@ impl fmt::Display for ManagedDirectory {
 
 impl Feature for ManagedDirectory {
     fn install(&self) -> Result<FeatureResult> {
-        if self.path.is_dir() {
+        let path = expand_tilde(&self.display_path)?;
+
+        if path.is_dir() {
             debug!(path = %self.display_path, "directory already exists");
             return Ok(FeatureResult::NoOp);
         }
-        if self.path.exists() {
+        if path.exists() {
             bail!("path exists but is not a directory: {}", self.display_path);
         }
-        fs::create_dir(&self.path)?;
+        fs::create_dir(&path)?;
         debug!(path = %self.display_path, "created directory");
         Ok(FeatureResult::Changed)
     }
 
     fn uninstall(&self) -> Result<FeatureResult> {
-        if !self.path.exists() {
+        let path = expand_tilde(&self.display_path)?;
+
+        if !path.exists() {
             debug!(path = %self.display_path, "directory already removed");
             return Ok(FeatureResult::NoOp);
         }
-        match fs::remove_dir(&self.path) {
+        match fs::remove_dir(&path) {
             Ok(()) => {
                 debug!(path = %self.display_path, "removed directory");
                 Ok(FeatureResult::Changed)

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -245,12 +245,20 @@ impl FeatureGraph {
                 continue;
             }
 
-            if let Some(cond) = &node.condition
-                && !cond.is_met()
-            {
-                info!("⏭️ skipped: {} ({})", node.feature, cond);
-                skipped.insert(id);
-                continue;
+            if let Some(cond) = &node.condition {
+                match cond.is_met() {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        info!("⏭️ skipped: {} ({})", node.feature, cond);
+                        skipped.insert(id);
+                        continue;
+                    }
+                    Err(e) => {
+                        error!("❌ {} condition failed: {}", node.feature, e);
+                        failed.insert(id);
+                        continue;
+                    }
+                }
             }
 
             debug!("installing feature: {:?}", node.feature);
@@ -397,6 +405,21 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct ErrorCondition;
+
+    impl std::fmt::Display for ErrorCondition {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "error condition")
+        }
+    }
+
+    impl Condition for ErrorCondition {
+        fn is_met(&self) -> Result<bool> {
+            bail!("condition exploded")
+        }
+    }
+
     #[test]
     fn install_respects_dependency_order() {
         let log = Arc::new(Mutex::new(Vec::new()));
@@ -445,6 +468,30 @@ mod tests {
 
         graph.install().unwrap();
 
+        assert!(log.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn install_fails_when_condition_cannot_be_evaluated() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut graph = FeatureGraph::new();
+
+        graph
+            .add("a", MockFeature::new("a", log.clone()))
+            .condition(ErrorCondition)
+            .build();
+
+        let stats = graph.install().unwrap();
+
+        assert_eq!(
+            stats,
+            RunStats {
+                changed: 0,
+                unchanged: 0,
+                skipped: 0,
+                failed: 1,
+            }
+        );
         assert!(log.lock().unwrap().is_empty());
     }
 

--- a/src/util/fs.rs
+++ b/src/util/fs.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Result, bail};
@@ -7,8 +8,17 @@ use anyhow::{Result, bail};
 /// Returns an error if the path starts with `~/` but the `HOME` environment
 /// variable is not set. Paths not starting with `~/` are returned unchanged.
 pub fn expand_tilde(path: &str) -> Result<PathBuf> {
+    expand_tilde_with_home(path, std::env::var_os("HOME"))
+}
+
+/// Expands a leading `~/` using an explicitly provided home directory.
+///
+/// This keeps the process environment out of tests that need to exercise the
+/// missing-`HOME` path. Callers that want normal runtime behavior should use
+/// [`expand_tilde`].
+pub fn expand_tilde_with_home(path: &str, home: Option<OsString>) -> Result<PathBuf> {
     if let Some(rest) = path.strip_prefix("~/") {
-        match std::env::var_os("HOME") {
+        match home {
             Some(home) => Ok(PathBuf::from(home).join(rest)),
             None => bail!("cannot expand ~: HOME environment variable is not set"),
         }
@@ -90,6 +100,12 @@ mod tests {
         let result = expand_tilde("~/config/file.txt").unwrap();
         assert!(result.to_string_lossy().ends_with("/config/file.txt"));
         assert!(!result.to_string_lossy().starts_with("~"));
+    }
+
+    #[test]
+    fn expand_tilde_reports_missing_home() {
+        let err = expand_tilde_with_home("~/config/file.txt", None).unwrap_err();
+        assert!(err.to_string().contains("HOME"));
     }
 
     #[test]


### PR DESCRIPTION
Missing HOME should be reported as a configuration error. Treating tilde paths as literal strings makes install decisions misleading and can hide the real cause.
