### PR TITLE
ci: require main as pr base

### DIFF
--- a/.github/workflows/pr-base.yml
+++ b/.github/workflows/pr-base.yml
@@ -1,0 +1,17 @@
+name: PR Base
+
+on:
+  pull_request:
+
+jobs:
+  require-main-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require main as PR base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "$BASE_REF" != "main" ]; then
+            echo "PR base must be main, got '$BASE_REF'." >&2
+            exit 1
+          fi


### PR DESCRIPTION
This applies the new modernization rule to this repo. The check must run on every pull request, not just pull requests targeting main, because stacked child PRs are the cases it needs to reject.

After this lands, the `require-main-base` check still needs to be made required in GitHub branch protection or a repository ruleset. Until then it is advisory.
