### PR TITLE
fix: make symlink repoint test pass on macos

### DIFF
--- a/src/features/payload_symlink.rs
+++ b/src/features/payload_symlink.rs
@@ -316,13 +316,15 @@ mod tests {
         let result = feature.install_with_base_dir(ctx.base_dir()).unwrap();
         assert_eq!(result, FeatureResult::Changed);
         assert_eq!(fs::read_to_string(&dest).unwrap(), "content");
+        // Canonicalize both sides: on macOS the tempdir lives behind the /var ->
+        // /private/var symlink, so only the resolved side would carry the /private prefix.
         assert_eq!(
             dest.parent()
                 .unwrap()
                 .join(fs::read_link(&dest).unwrap())
                 .canonicalize()
                 .unwrap(),
-            source
+            source.canonicalize().unwrap()
         );
     }
 


### PR DESCRIPTION
The repoint test canonicalizes the resolved link target but compared it against the raw tempdir path. On macOS, tempdirs live behind the /var -> /private/var symlink, so the resolved side gains a /private prefix the expectation lacks and the test fails locally despite passing on Linux CI. Canonicalizing both sides keeps the assertion meaningful on either platform.
