### PR TITLE
fix: reorder cliff.toml parsers so commit types group correctly

### DIFF
--- a/agent-skills/scode-dist-rust-setup/SKILL.md
+++ b/agent-skills/scode-dist-rust-setup/SKILL.md
@@ -154,7 +154,9 @@ verify `release.yml` references it correctly.
    - Use distinct group names: "Added" for feat, "Fixed" for fix, "Performance" for perf, "Reverted" for revert.
    - Include by default: `feat`, `fix`, `perf`, `revert`.
    - Skip by default: `refactor`, `style`, `test`, `chore`, `ci`, `docs`, `doc`.
-   - Parse override tags first: `changelog: include` forces inclusion, `changelog: skip` forces exclusion.
+   - Parser order matters: `changelog: skip` overrides first, then type-based grouping, then `changelog: include` as a
+     rescue for otherwise-skipped types. The include rules must NOT come before the type rules — every PR body carries a
+     changelog tag (CI-enforced), so an early include rule would group every commit under "Changed".
    - If both tags are present, `changelog: skip` wins.
 4. Update `CONTRIBUTING.md` with:
    - Conventional Commit requirements for commit messages and PR titles.

--- a/agent-skills/scode-dist-rust-setup/references/git-cliff-and-changelog-flow.md
+++ b/agent-skills/scode-dist-rust-setup/references/git-cliff-and-changelog-flow.md
@@ -19,23 +19,33 @@ Replace the default `commit_parsers` with:
 
 ```toml
 commit_parsers = [
-  # Override tags: "changelog: skip" forces exclusion, "changelog: include" forces inclusion.
-  # When both are present, skip wins. Check message, body, and footer.
+  # "changelog: skip" forces exclusion and wins over everything else, so it
+  # goes first. Check message, body, and footer.
   { message = "(?i)\\bchangelog\\s*:\\s*skip\\b", skip = true },
   { body = "(?i)\\bchangelog\\s*:\\s*skip\\b", skip = true },
   { footer = "(?i)\\bchangelog\\s*:\\s*skip\\b", skip = true },
-  { message = "(?i)\\bchangelog\\s*:\\s*include\\b", group = "Changed" },
-  { body = "(?i)\\bchangelog\\s*:\\s*include\\b", group = "Changed" },
-  { footer = "(?i)\\bchangelog\\s*:\\s*include\\b", group = "Changed" },
   # Conventional Commit types included in changelog (user-visible changes).
+  # These must run before the "changelog: include" override below: PR bodies
+  # always contain a changelog tag (CI-enforced), and if the include override
+  # ran first it would force every commit into "Changed" regardless of type.
   { message = "^feat(\\([^\\)]+\\))?!?:", group = "Added" },
   { message = "^fix(\\([^\\)]+\\))?!?:", group = "Fixed" },
   { message = "^perf(\\([^\\)]+\\))?!?:", group = "Performance" },
   { message = "^revert(\\([^\\)]+\\))?!?:", group = "Reverted" },
+  # "changelog: include" rescues commit types that would otherwise be skipped
+  # (e.g. a refactor worth calling out); they land under "Changed".
+  { message = "(?i)\\bchangelog\\s*:\\s*include\\b", group = "Changed" },
+  { body = "(?i)\\bchangelog\\s*:\\s*include\\b", group = "Changed" },
+  { footer = "(?i)\\bchangelog\\s*:\\s*include\\b", group = "Changed" },
   # Conventional Commit types excluded from changelog (non-user-visible).
   { message = "^(docs|doc|refactor|style|test|chore|ci)(\\([^\\)]+\\))?!?:", skip = true },
 ]
 ```
+
+NOTE: Parser order is load-bearing. An earlier version of this skill placed the `changelog: include` rules before the
+type-based rules. Because CI requires every PR body to carry a changelog tag, squash-merged commits always matched the
+include rule first and every entry was grouped under "Changed" — fix commits never reached the "Fixed" group. Keep the
+order: skip overrides, then type grouping, then the include rescue, then type-based skips.
 
 ### Other settings
 

--- a/agent-skills/scode-modernize/SKILL.md
+++ b/agent-skills/scode-modernize/SKILL.md
@@ -415,3 +415,32 @@ jobs:
 
 **Verify:** Open or inspect a PR whose base is not `main` and confirm the `require-main-base` job fails. Confirm the
 same check is configured as required for merges to `main`; otherwise the workflow is advisory only.
+
+### 10. Fix `changelog: include` parser ordering in `cliff.toml` (git-cliff projects)
+
+**Detect:** The project has a `cliff.toml` with a `commit_parsers` list in which a rule matching `changelog: include`
+(in message, body, or footer) appears _before_ the type-based grouping rules (`^feat`, `^fix`, `^perf`, `^revert`).
+
+**Skip if:** There is no `cliff.toml`, there are no `changelog: include` parser rules at all, or the include rules
+already come after the type-based grouping rules.
+
+**Why:** git-cliff applies the first matching parser. In repos where CI requires every PR body to carry a
+`changelog: include` / `changelog: skip` tag, squash-merged commits always contain a tag in the body — so an early
+include rule matches first and forces every entry into its group (typically "Changed"). Fix commits never reach the
+"Fixed" group and the generated changelog misclassifies everything. This bit saltybox: every release section came out as
+"### Changed" until the parsers were reordered.
+
+**Replace with:**
+
+- Reorder `commit_parsers` to: `changelog: skip` overrides first (skip must win over everything), then the type-based
+  grouping rules (`feat` → Added, `fix` → Fixed, `perf` → Performance, `revert` → Reverted), then the
+  `changelog: include` rules (which now only rescue commit types that would otherwise be skipped), then the type-based
+  skip rule for non-user-visible types.
+- The corrected block, with rationale comments, is in
+  `agent-skills/scode-dist-rust-setup/references/git-cliff-and-changelog-flow.md` — keep the two in sync.
+- After reordering, regenerate the changelog (`git-cliff --tag <current-tag> -o CHANGELOG.md`) and review the diff:
+  entries for past releases may legitimately move between groups (that is the fix working). Watch for hand-written
+  sections that regeneration drops; restore them manually.
+
+**Verify:** In `cliff.toml`, the first `changelog\s*:\s*include` rule appears on a later line than the `^fix` grouping
+rule. Regenerating the changelog puts `fix:` commits under "### Fixed", not "### Changed".


### PR DESCRIPTION
While cutting saltybox 3.3.1, every commit in the generated changelog landed under "Changed" regardless of type. The templated cliff.toml put the `changelog: include` override ahead of the type-grouping parsers, and git-cliff applies the first matching parser. Since CI requires every PR body to carry a changelog tag, the include rule matched every commit and `fix:` commits never reached "Fixed".

The corrected ordering (skip overrides first, then type grouping, then include as a rescue for otherwise-skipped types) was first applied in saltybox itself (scode/saltybox#205). This propagates it to the scode-dist-rust-setup template and adds a scode-modernize checklist item that detects and repairs the bad ordering in existing projects. The modernize item warns that regenerating the changelog legitimately moves past entries between groups and drops hand-written sections, which must be restored manually.
